### PR TITLE
change inhabited to nonempty in lemma models_all_or_none_sentences

### DIFF
--- a/src/model.lean
+++ b/src/model.lean
@@ -672,7 +672,7 @@ end
 either `M ⊨ σ[s]` for all variable assignments or `M ⊨ σ[s]` for no
 variable assignment.-/
 lemma models_formula_all_or_none_sentences {L: lang} (M : struc L)
-  [inhabited M.univ] (σ : sentence L) :
+  [nonempty M.univ] (σ : sentence L) :
   xor (∀ va : ℕ → M.univ, va ⊨ σ.val) (∀ va' : ℕ → M.univ, ¬ va' ⊨ σ.val) :=
 begin
   unfold xor,
@@ -681,6 +681,7 @@ begin
   left,
   split,
   rotate,
+  inhabit M.univ,
   use function.const ℕ (arbitrary M.univ),
  cases σ₁,
  repeat {sorry},


### PR DESCRIPTION
This change was prompted by Lean's linter reporting that nonempty
is preferred over inhabited. However, we were using the inhabited
assumption in the proof since we referenced (arbitrary M.univ).

To fix the usage of arbitrary, we precede it with the tactic line
`inhabit M.univ`. This converts nonempty into an inhabited
assumption, and then the proof proceeds as before.